### PR TITLE
2 digits or higher versions

### DIFF
--- a/lib/core/functions/convert_version.dart
+++ b/lib/core/functions/convert_version.dart
@@ -12,7 +12,7 @@ convertVersion({String? version, String? versionStore}) {
 
   /// add all values of array in localversion array.
   localVersion.addAll(
-      [version.split('.')[0], version.split('.')[1], version.split('.')[2][0]]);
+      [version.split('.')[0], version.split('.')[1], version.split('.')[2]]);
 
   /// verify if exist + char in content version string.
   if (versionStore!.contains('+')) {
@@ -23,7 +23,7 @@ convertVersion({String? version, String? versionStore}) {
   storeVersion.addAll([
     versionStore.split('.')[0],
     versionStore.split('.')[1],
-    versionStore.split('.')[2][0]
+    versionStore.split('.')[2]
   ]);
 
   /// Loop for verify values.


### PR DESCRIPTION
When comparing 1.0.9 with 1.0.10 the function `convertVersion` returns `false` when it should return `true`.

The last digit `0` is ignored. 
```
version = 1.0.9
versionStore = 1.0.10
localVersion = [1, 0, 9]
storeVersion = [1, 0, 1]
```