### PR TITLE
Fix a bug where custom text styles are not applied

### DIFF
--- a/lib/app_version_update.dart
+++ b/lib/app_version_update.dart
@@ -123,11 +123,11 @@ class AppVersionUpdate {
       AppVersionResult? appVersionResult,
       bool? mandatory = false,
       String? title = 'New version available',
-      TextStyle? titleTextStyle =
-          const TextStyle(fontSize: 24.0, fontWeight: FontWeight.w500),
+      TextStyle? titleTextStyle = const TextStyle(
+          fontSize: 24.0, fontWeight: FontWeight.w500, color: Colors.black),
       String? content = 'Would you like to update your application?',
-      TextStyle? contentTextStyle =
-          const TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
+      TextStyle? contentTextStyle = const TextStyle(
+          fontSize: 16.0, fontWeight: FontWeight.w400, color: Colors.black),
       ButtonStyle? cancelButtonStyle = const ButtonStyle(
           backgroundColor: MaterialStatePropertyAll(Colors.redAccent)),
       ButtonStyle? updateButtonStyle = const ButtonStyle(

--- a/lib/app_version_update.dart
+++ b/lib/app_version_update.dart
@@ -123,10 +123,10 @@ class AppVersionUpdate {
       AppVersionResult? appVersionResult,
       bool? mandatory = false,
       String? title = 'New version available',
-      TextStyle titleTextStyle =
+      TextStyle? titleTextStyle =
           const TextStyle(fontSize: 24.0, fontWeight: FontWeight.w500),
       String? content = 'Would you like to update your application?',
-      TextStyle contentTextStyle =
+      TextStyle? contentTextStyle =
           const TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
       ButtonStyle? cancelButtonStyle = const ButtonStyle(
           backgroundColor: MaterialStatePropertyAll(Colors.redAccent)),

--- a/lib/widgets/alert_dialog_update.dart
+++ b/lib/widgets/alert_dialog_update.dart
@@ -32,8 +32,7 @@ class UpdateVersionDialog extends Container {
       this.cancelButtonStyle,
       this.cancelTextStyle,
       this.contentTextStyle,
-      this.titleTextStyle =
-          const TextStyle(fontSize: 18.0, fontWeight: FontWeight.w700),
+      this.titleTextStyle,
       Key? key})
       : super(key: key);
 
@@ -43,12 +42,19 @@ class UpdateVersionDialog extends Container {
         backgroundColor: backgroundColor!,
         title: Text(
           title!,
-          style: const TextStyle(fontSize: 20.0, fontWeight: FontWeight.w700),
+          style: titleTextStyle ??
+              const TextStyle(
+                  color: Colors.black,
+                  fontSize: 20.0,
+                  fontWeight: FontWeight.w700),
         ),
         content: Text(
           content!,
-          style: const TextStyle(
-              color: Colors.black, fontSize: 16.0, fontWeight: FontWeight.w400),
+          style: contentTextStyle ??
+              const TextStyle(
+                  color: Colors.black,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400),
         ),
         actions: [
           mandatory!


### PR DESCRIPTION
Hi, thanks for the package.

Don't know if it intentional, but custom textStyle for title and content are not applied.

Also forced the color black to the title default, since the background is defaulted to white (problem with the dark mode).