### PR TITLE
Fixing version comparison where lengths are different

### DIFF
--- a/lib/core/extensions/list_extensions.dart
+++ b/lib/core/extensions/list_extensions.dart
@@ -1,0 +1,8 @@
+extension ListExtensions<T> on List<T> {
+  T getOrDefault(int index, T defaultValue) {
+    if (index < 0 || index >= length) {
+      return defaultValue;
+    }
+    return this[index];
+  }
+}

--- a/lib/core/functions/convert_version.dart
+++ b/lib/core/functions/convert_version.dart
@@ -1,3 +1,7 @@
+import 'dart:math';
+
+import '../extensions/list_extensions.dart';
+
 /// Convert string of the stores for list number and compare.
 /// * ```version``` local version app.
 /// * ```versionStore``` store version app.
@@ -24,14 +28,17 @@ convertVersion({String? version, String? versionStore}) {
   storeVersion.addAll(versionStore.split('.'));
 
   /// Loop for verify values.
-  for (int i = 0; i < localVersion.length; i++) {
+  var maxLength = max(localVersion.length, storeVersion.length);
+  for (int i = 0; i < maxLength; i++) {
     /// if any of the store elements is smaller than a corresponding element of local version we will exit the function with false.
-    if (int.parse(storeVersion[i]) < int.parse(localVersion[i])) {
+    if (int.parse(storeVersion.getOrDefault(i, '0')) <
+        int.parse(localVersion.getOrDefault(i, '0'))) {
       return false;
     }
 
     /// if any element of the store version is greater than the corresponding local version, there is an update.
-    if (int.parse(storeVersion[i]) > int.parse(localVersion[i])) {
+    if (int.parse(storeVersion.getOrDefault(i, '0')) >
+        int.parse(localVersion.getOrDefault(i, '0'))) {
       return true;
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app_version_update
 description: An easy and quick way to check if the local app is updated with the same version in their respective stores (Play Store / Apple Store ).
 # author: Kauê Tomaz Murakami<kauetmurakami@gmail.com>
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/kauemurakami/app_version_update
 
 environment:

--- a/test/app_version_update_test.dart
+++ b/test/app_version_update_test.dart
@@ -1,0 +1,24 @@
+import 'package:app_version_update/core/functions/convert_version.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('handles comparing versions of different lengths', () {
+    var result = convertVersion(version: '1.0.0', versionStore: '1.0');
+    expect(result, false);
+
+    result = convertVersion(version: '1.3.0', versionStore: '1.4');
+    expect(result, true);
+
+    result = convertVersion(version: '1.3', versionStore: '1.4.0');
+    expect(result, true);
+
+    result = convertVersion(version: '1.3.0', versionStore: '1.4.0');
+    expect(result, true);
+
+    result = convertVersion(version: '1.4.0', versionStore: '1.3.0');
+    expect(result, false);
+
+    result = convertVersion(version: '1.4.0', versionStore: '1.3');
+    expect(result, false);
+  });
+}


### PR DESCRIPTION
This change allows for version lengths to be different between the store and local. It assumes zeros on the shorter version number.