### PR TITLE
Fix itunes connect url generation when using the bundle id instead of apple id

### DIFF
--- a/lib/core/functions/fetch_version.dart
+++ b/lib/core/functions/fetch_version.dart
@@ -57,8 +57,9 @@ Future<AppVersionData> fetchAndroid(
 
 Future<AppVersionData> fetchIOS(
     {PackageInfo? packageInfo, String? appleId, String? country}) async {
-  appleId = appleId ?? packageInfo?.packageName;
-  final parameters = {"id": appleId};
+  assert(appleId != null || packageInfo != null,
+      'One between appleId or packageInfo must not be null');
+  final parameters = (appleId != null) ? {"id": appleId} : {'bundleId': packageInfo?.packageName};
   var uri = Uri.https(appleStoreAuthority, '/$country/lookup', parameters);
   final response = await http.get(uri, headers: headers);
   if (response.statusCode == 200) {

--- a/lib/core/functions/fetch_version.dart
+++ b/lib/core/functions/fetch_version.dart
@@ -59,8 +59,11 @@ Future<AppVersionData> fetchIOS(
     {PackageInfo? packageInfo, String? appleId, String? country}) async {
   assert(appleId != null || packageInfo != null,
       'One between appleId or packageInfo must not be null');
-  final parameters = (appleId != null) ? {"id": appleId} : {'bundleId': packageInfo?.packageName};
-  var uri = Uri.https(appleStoreAuthority, '/$country/lookup', parameters);
+  var parameters = (appleId != null) ? {"id": appleId} : {'bundleId': packageInfo?.packageName};
+  if (country != null) {
+    parameters['country'] = country;
+  }
+  var uri = Uri.https(appleStoreAuthority, '/lookup', parameters);
   final response = await http.get(uri, headers: headers);
   if (response.statusCode == 200) {
     final jsonResult = json.decode(response.body);


### PR DESCRIPTION
Fix the itunes lookup search url generation.
Using the package id with the appleId parameter causes error.

Here a stackoverflow reference: https://stackoverflow.com/questions/8839328/itunes-api-lookup-by-bundle-id/23336717#23336717

And here the official documentation about query parameters:
https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI/Searching.html#//apple_ref/doc/uid/TP40017632-CH5-SW1
