### PR TITLE
Send version parameter in itunes api

### DIFF
--- a/lib/core/functions/fetch_version.dart
+++ b/lib/core/functions/fetch_version.dart
@@ -93,6 +93,7 @@ Future<AppVersionData> fetchIOS(
   if (country != null) {
     parameters['country'] = country;
   }
+    parameters['version'] = 2;
   var uri = Uri.https(appleStoreAuthority, '/lookup', parameters);
   final response = await http.get(uri, headers: headers);
   if (response.statusCode == 200) {


### PR DESCRIPTION
Why:
* Apperently, not sending "version" params will not fetch latest version from app store. As mentioned [here](https://forums.developer.apple.com/forums/thread/113983), it will only fetch the latest version after 24hrs of release in app store.

